### PR TITLE
Exponer puerto del datawarehouse

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,8 @@ services:
       - POSTGRES_USER=admin
       - POSTGRES_DB=datawarehouse
       - PGDATA=/volume/data
+    ports:
+      - "6666:5432"
     networks:
       facturacion:
         ipv4_address: 172.40.0.30


### PR DESCRIPTION
Bueno a ver, este PR se hace por lo siguiente:

La imagen de docker de pentaho me parece que está media chori (o yo no lo sé usar, que puede ser eh), pero no le encuentro la forma de crear un cubito ni nada. Así que lo que quiero hacer es instalar pentaho en una máquina virtual (no me lo pienso instalar en mi compu, no no) y desde esa máquina virtual conectarme al DW y armar los reportes y los cubos y toda la bola OLAP